### PR TITLE
Always pass --config at the end of the command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 ---
-sudo: false
 language: ruby
-cache: bundler
 rvm:
-  - 2.4
   - 2.5
   - 2.6
+  - 2.7
+before_install:
+  - gem install bundler

--- a/lib/mco_env.rb
+++ b/lib/mco_env.rb
@@ -29,13 +29,10 @@ module McoEnv
     end
 
     def run(args)
-      action = args.shift
-
       command = []
       command << mco_path
-      command << action unless action.nil?
-      command += ['--config', config_path] if config_path?
       command += args
+      command += ['--config', config_path] if config_path?
       system(*command)
       $CHILD_STATUS.exitstatus
     end


### PR DESCRIPTION
Passing it as early as possible appends not to be so wise, since some
commands may expect 1 and up to 2 arguments before any options are
accepted.