### PR TITLE
Fix exit status

### DIFF
--- a/lib/mco_env.rb
+++ b/lib/mco_env.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'English'
+
 module McoEnv
   module Utils
     def self.all_environments


### PR DESCRIPTION
The $CHILD_STATUS global variable is provided by English and is not
required, causing exception on each run:

```sh-session
romain@zappy ~ $ mco package refresh -y

 * [ ============================================================> ] 15 / 15

Finished processing 15 / 15 hosts in 20608.70 ms

Traceback (most recent call last):
	3: from /home/romain/.gem/ruby/2.6/bin/mco:23:in `<main>'
	2: from /home/romain/.gem/ruby/2.6/bin/mco:23:in `load'
	1: from /usr/home/romain/.gem/ruby/2.6/gems/mco_env-1.2.0/exe/mco:7:in `<top (required)>'
/usr/home/romain/.gem/ruby/2.6/gems/mco_env-1.2.0/lib/mco_env.rb:37:in `run': undefined method `exitstatus' for nil:NilClass (NoMethodError)
romain@zappy ~ $ echo $?
1
```